### PR TITLE
interface: define interface for handlers

### DIFF
--- a/handler/EthereumBlockHandler.go
+++ b/handler/EthereumBlockHandler.go
@@ -1,0 +1,8 @@
+package handler
+
+import "github.com/Zettablock/zsource/utils"
+
+// Custom ethereum block handler should implement this interface.
+type EthereumBlockHandler interface {
+	Handle(blockNumber string, deps *utils.Deps) (bool, error)
+}

--- a/handler/EthereumLogHandler.go
+++ b/handler/EthereumLogHandler.go
@@ -1,0 +1,11 @@
+package handler
+
+import (
+	"github.com/Zettablock/zsource/dao/ethereum"
+	"github.com/Zettablock/zsource/utils"
+)
+
+// Custom ethereum log handler should implement this interface.
+type EthereumLogHandler interface {
+	Handle(log ethereum.Log, deps *utils.Deps) (bool, error)
+}

--- a/handler/README.md
+++ b/handler/README.md
@@ -1,0 +1,1 @@
+This directory contains interfaces for custom handlers. Custom logic should implement the proper interface in order to be processed by the system. See `examples.go` for examples.

--- a/handler/examples.go
+++ b/handler/examples.go
@@ -1,0 +1,28 @@
+package handler
+
+import (
+	"github.com/Zettablock/zsource/dao/ethereum"
+	"github.com/Zettablock/zsource/utils"
+)
+
+// Example for custom Ethereum log handler.
+type ExampleEthereumLogHandler struct {
+}
+
+// Verify interface compliance.
+var _ EthereumLogHandler = (*ExampleEthereumLogHandler)(nil)
+
+func (h *ExampleEthereumLogHandler) Handle(log ethereum.Log, deps *utils.Deps) (bool, error) {
+	return false, nil
+}
+
+// Example for custom Ethereum block handler.
+type ExampleEthereumBlockHandler struct {
+}
+
+// Verify interface compliance.
+var _ EthereumBlockHandler = (*ExampleEthereumBlockHandler)(nil)
+
+func (h *ExampleEthereumBlockHandler) Handle(blockNumber string, deps *utils.Deps) (bool, error) {
+	return false, nil
+}


### PR DESCRIPTION
Define the handler function signature as interfaces. This has the following benefits:
* It allows us to communicate the function signature by code instead of using docs and makes handler development easier.
* It allows customer to verify interface compliance to catch potential errors earlier.
* It makes it easy to unit test the handler as we can test against the interface instead of the actual implementation.