### PR TITLE
ZB-1512 3: call handler in TestRunner and user provided checker

### DIFF
--- a/testexamples/ethereum_block_handler_test.go
+++ b/testexamples/ethereum_block_handler_test.go
@@ -1,6 +1,7 @@
 package examples
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/Zettablock/zsource/dao/ethereum"
@@ -10,15 +11,15 @@ import (
 
 func FindBlockHandlerString(blockNumber string, deps *utils.Deps) (bool, error) {
 	if blockNumber == "2" {
-		// TODO(meng): write to destination db.
+		deps.DestinationDB.Create(&ethereum.Block{Number: 2})
 		return false, nil
 	}
 	return false, nil
 }
 
 func FindBlockHandlerInt64(blockNumber int64, deps *utils.Deps) (bool, error) {
-	if blockNumber == 2 {
-		// TODO(meng): write to destination db.
+	if blockNumber == 3 {
+		deps.DestinationDB.Create(&ethereum.Block{Number: 3})
 		return false, nil
 	}
 	return false, nil
@@ -33,6 +34,19 @@ func TestHandlers(t *testing.T) {
 	runner := testutils.NewEthereumBlockHandlerTestRunner(t, sourceData)
 	defer runner.Close()
 
-	runner.TestHandlerString(FindBlockHandlerString, 0)
-	runner.TestHandlerInt64(FindBlockHandlerInt64, 0)
+	// Returns a checker function that checks the table in destination database
+	// has expected count of rows.
+	checkerMaker := func(rowCountExp int64) testutils.DepsChecker {
+		return func(deps *utils.Deps) error {
+			var rowCountActual int64
+			deps.DestinationDB.Table("ethereum.blocks").Count(&rowCountActual)
+			if rowCountActual != rowCountExp {
+				return fmt.Errorf("expected %d rows, got %d", rowCountExp, rowCountActual)
+			}
+			return nil
+		}
+	}
+
+	runner.TestHandlerString(FindBlockHandlerString, checkerMaker(1))
+	runner.TestHandlerInt64(FindBlockHandlerInt64, checkerMaker(2))
 }


### PR DESCRIPTION
This PR adds the functionality in `EthereumBlockHandlerTestRunner` to call the custom handler and also call the custom checker to verify the destination database state after the handlers are ran. Handlers are called on every row of the source data.