### PR TITLE
ZB-1512 10: annotate timestamp column with no timezone type

### DIFF
--- a/dao/ethereum/blocks.gen.go
+++ b/dao/ethereum/blocks.gen.go
@@ -3,10 +3,11 @@ package ethereum
 import (
 	"context"
 	"fmt"
-	"github.com/lib/pq"
-	"gorm.io/gorm"
 	"math/rand"
 	"time"
+
+	"github.com/lib/pq"
+	"gorm.io/gorm"
 )
 
 // Block mapped from table <blocks>
@@ -28,13 +29,13 @@ type Block struct {
 	GasLimit          int64          `gorm:"column:gas_limit;not null" json:"gas_limit"`
 	GasUsed           int64          `gorm:"column:gas_used;not null" json:"gas_used"`
 	BaseFeePerGas     int64          `gorm:"column:base_fee_per_gas" json:"base_fee_per_gas"`
-	Timestamp         time.Time      `gorm:"column:timestamp;not null" json:"timestamp"`
+	Timestamp         time.Time      `gorm:"column:timestamp;not null;type:timestamp" json:"timestamp"`
 	Uncles            pq.StringArray `gorm:"column:uncles;type:text[]" json:"uncles"`
 	NumOfTransactions int32          `gorm:"column:num_of_transactions;not null" json:"num_of_transactions"`
 	ExtraDataRaw      string         `gorm:"column:extra_data_raw" json:"extra_data_raw"`
 	ExtraData         string         `gorm:"column:extra_data" json:"extra_data"`
-	ProcessTime       time.Time      `gorm:"column:process_time" json:"process_time"`
-	BlockDate         time.Time      `gorm:"column:block_date" json:"block_date"`
+	ProcessTime       time.Time      `gorm:"column:process_time;type:timestamp" json:"process_time"`
+	BlockDate         time.Time      `gorm:"column:block_date;type:timestamp" json:"block_date"`
 }
 
 // TableName Block's table name

--- a/dao/ethereum/logs.gen.go
+++ b/dao/ethereum/logs.gen.go
@@ -3,10 +3,11 @@ package ethereum
 import (
 	"context"
 	"fmt"
-	"github.com/lib/pq"
-	"gorm.io/gorm"
 	"math/rand"
 	"time"
+
+	"github.com/lib/pq"
+	"gorm.io/gorm"
 )
 
 // Log mapped from table <logs>
@@ -26,10 +27,10 @@ type Log struct {
 	ArgumentNames    pq.StringArray `gorm:"column:argument_names;type:text[]" json:"argument_names"`
 	ArgumentTypes    pq.StringArray `gorm:"column:argument_types;type:text[]" json:"argument_types"`
 	ArgumentValues   pq.StringArray `gorm:"column:argument_values;type:text[]" json:"argument_values"`
-	BlockTime        time.Time      `gorm:"column:block_time;not null" json:"block_time"`
+	BlockTime        time.Time      `gorm:"column:block_time;not null;type:timestamp" json:"block_time"`
 	DecodedFromAbi   bool           `gorm:"column:decoded_from_abi" json:"decoded_from_abi"`
-	ProcessTime      time.Time      `gorm:"column:process_time" json:"process_time"`
-	BlockDate        time.Time      `gorm:"column:block_date" json:"block_date"`
+	ProcessTime      time.Time      `gorm:"column:process_time;type:timestamp" json:"process_time"`
+	BlockDate        time.Time      `gorm:"column:block_date;type:timestamp" json:"block_date"`
 }
 
 // TableName Log's table name

--- a/dao/ethereum/traces.gen.go
+++ b/dao/ethereum/traces.gen.go
@@ -3,10 +3,11 @@ package ethereum
 import (
 	"context"
 	"fmt"
-	"github.com/lib/pq"
-	"gorm.io/gorm"
 	"math/rand"
 	"time"
+
+	"github.com/lib/pq"
+	"gorm.io/gorm"
 )
 
 // Trace mapped from table <traces>
@@ -15,7 +16,7 @@ type Trace struct {
 	TransactionIndex  int32          `gorm:"column:transaction_index" json:"transaction_index"`
 	BlockNumber       int64          `gorm:"column:block_number;not null" json:"block_number"`
 	BlockHash         string         `gorm:"column:block_hash;not null" json:"block_hash"`
-	BlockTime         time.Time      `gorm:"column:block_time;not null" json:"block_time"`
+	BlockTime         time.Time      `gorm:"column:block_time;not null;type:timestamp" json:"block_time"`
 	FromAddress       string         `gorm:"column:from_address" json:"from_address"`
 	ToAddress         string         `gorm:"column:to_address" json:"to_address"`
 	Value             float64        `gorm:"column:value;not null" json:"value"`
@@ -43,8 +44,8 @@ type Trace struct {
 	TraceID           string         `gorm:"column:trace_id;primaryKey" json:"trace_id"`
 	TraceIndex        int32          `gorm:"column:trace_index" json:"trace_index"`
 	DecodedFromAbi    bool           `gorm:"column:decoded_from_abi" json:"decoded_from_abi"`
-	ProcessTime       time.Time      `gorm:"column:process_time" json:"process_time"`
-	BlockDate         time.Time      `gorm:"column:block_date;primaryKey" json:"block_date"`
+	ProcessTime       time.Time      `gorm:"column:process_time;type:timestamp" json:"process_time"`
+	BlockDate         time.Time      `gorm:"column:block_date;primaryKey;type:timestamp" json:"block_date"`
 }
 
 // TableName Trace's table name

--- a/testexamples/ethereum_block_handler_test.go
+++ b/testexamples/ethereum_block_handler_test.go
@@ -3,6 +3,7 @@ package examples
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/Zettablock/zsource/dao/ethereum"
 	"github.com/Zettablock/zsource/testutils"
@@ -38,6 +39,16 @@ func FindBlockHandlerInt64(blockNumber int64, deps *utils.Deps) (bool, error) {
 	return false, nil
 }
 
+func TimeHandlerInt64(blockNumber int64, deps *utils.Deps) (bool, error) {
+	if blockNumber == 3 {
+		var logs []*ethereum.Log
+		deps.SourceDB.Raw("SELECT * FROM ethereum.logs").Scan(&logs)
+		fmt.Printf("logs: %v\n", logs[0].BlockTime)
+		return false, nil
+	}
+	return false, nil
+}
+
 // Example of using the EthereumBlockHandlerTestRunner to test block handlers.
 func TestHandlers(t *testing.T) {
 	// Prepare source schema and data.
@@ -48,8 +59,8 @@ func TestHandlers(t *testing.T) {
 		{Number: 3},
 	}
 	logs := []*ethereum.Log{
-		{TransactionHash: "tx1", BlockNumber: 2, LogIndex: 1},
-		{TransactionHash: "tx1", BlockNumber: 2, LogIndex: 2},
+		{TransactionHash: "tx1", BlockNumber: 2, LogIndex: 1, BlockTime: time.Date(2024, time.April, 16, 10, 30, 0, 0, time.UTC)},
+		{TransactionHash: "tx1", BlockNumber: 2, LogIndex: 2, BlockTime: time.Date(2024, time.April, 16, 10, 30, 0, 0, time.UTC)},
 	}
 	sourceData.AddSchemaData("ethereum", blocks, logs)
 	sourceData.AddSchemaData("ethereum_mainnet", blocks, logs)
@@ -92,4 +103,5 @@ func TestHandlers(t *testing.T) {
 
 	runner.TestHandlerString("ethereum", "ethereum_dest", FindBlockHandlerString, checkerMaker("ethereum", 1), customTableCheckerMaker(1))
 	runner.TestHandlerInt64("ethereum_mainnet", "ethereum_dest", FindBlockHandlerInt64, checkerMaker("ethereum_mainnet", 1), customTableCheckerMaker(2))
+	runner.TestHandlerInt64("ethereum", "ethereum", TimeHandlerInt64)
 }

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -14,7 +14,7 @@ import (
 // models without specifying the table name. Otherwise, table is default to be
 // in the public schema.
 func GetDbFromContianer(container *postgres.PostgresContainer, schemaName string) (*gorm.DB, error) {
-	url, err := container.ConnectionString(context.Background(), "TimeZone=UTC")
+	url, err := container.ConnectionString(context.Background())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
So that automigrate creates the table with `timestamp without timezone`.